### PR TITLE
SUPESC-755 Fixed Unzer notifications processing order.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
             fail-fast: false
             matrix:
                 php-versions:
-                    - '8.0'
                     - '8.1'
+                    - '8.2'
 
         services:
             mariadb:
@@ -117,7 +117,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
                   extensions: mbstring, intl, bcmath, pdo_mysql
 
             - name: Composer Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on:
 jobs:
     setup:
         name: Setup Database MariaDB
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
 
         steps:
             - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     ci:
         name: Unzer (PHP ${{ matrix.php-versions }})
         needs: setup
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
 
     lowest:
         name: Unzer Prefer Lowest (PHP ${{ matrix.php-versions }})
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
 
         steps:
             - name: Checkout

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![CI](https://github.com/spryker-eco/unzer/actions/workflows/ci.yml/badge.svg)](https://github.com/spryker-eco/unzer/actions/workflows/ci.yml)
 [![Latest Stable Version](https://poser.pugx.org/spryker-eco/unzer/v/stable.svg)](https://packagist.org/packages/spryker-eco/unzer)
 [![License](https://img.shields.io/github/license/spryker-eco/unzer.svg?b=master)](https://github.com/spryker-eco/unzer)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 
 Unzer module provides main business logic for Unzer regular and marketplace payment system integrations.
 

--- a/codeception.yml
+++ b/codeception.yml
@@ -9,6 +9,7 @@ paths:
   tests: tests
   support: .
   log: tests/_output
+  output: tests/_output
   data: tests/_data
   envs: tests/_envs
 

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "spryker/zed-request": "^3.0.0"
     },
     "require-dev": {
-        "codeception/module-asserts": "^1.3.0",
-        "phpstan/phpstan": "^1.2.0",
+        "codeception/module-asserts": "*",
+        "phpstan/phpstan": "*",
         "spryker/application": "*",
         "spryker/code-sniffer": "*",
         "spryker/customer": "*",
@@ -44,7 +44,7 @@
         "spryker/queue": "*",
         "spryker/router": "*",
         "spryker/state-machine": "*",
-        "spryker/testify": "^3.43.0"
+        "spryker/testify": "*"
     },
     "suggest": {
         "spryker/checkout": "Use this module if you want to use Checkout plugins.",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Unzer module",
     "license": "MIT",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "spryker-eco/unzer-api": "^1.1.0",
         "spryker-shop/shop-ui": "^1.56.0",
         "spryker/calculation": "^4.0.0",

--- a/src/SprykerEco/Zed/Unzer/Business/Notification/Processor/UnzerNotificationProcessor.php
+++ b/src/SprykerEco/Zed/Unzer/Business/Notification/Processor/UnzerNotificationProcessor.php
@@ -15,6 +15,7 @@ use Generated\Shared\Transfer\UnzerPaymentTransfer;
 use SprykerEco\Zed\Unzer\Business\ApiAdapter\UnzerPaymentAdapterInterface;
 use SprykerEco\Zed\Unzer\Business\Credentials\UnzerCredentialsResolverInterface;
 use SprykerEco\Zed\Unzer\Business\Payment\Mapper\UnzerPaymentMapperInterface;
+use SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolverInterface;
 use SprykerEco\Zed\Unzer\Business\Payment\Updater\UnzerPaymentUpdaterInterface;
 use SprykerEco\Zed\Unzer\Business\Reader\UnzerReaderInterface;
 use SprykerEco\Zed\Unzer\UnzerConfig;
@@ -24,32 +25,37 @@ class UnzerNotificationProcessor implements UnzerNotificationProcessorInterface
     /**
      * @var \SprykerEco\Zed\Unzer\Business\ApiAdapter\UnzerPaymentAdapterInterface
      */
-    protected $unzerPaymentAdapter;
+    protected UnzerPaymentAdapterInterface $unzerPaymentAdapter;
 
     /**
      * @var \SprykerEco\Zed\Unzer\UnzerConfig
      */
-    protected $unzerConfig;
+    protected UnzerConfig $unzerConfig;
 
     /**
      * @var \SprykerEco\Zed\Unzer\Business\Reader\UnzerReaderInterface
      */
-    protected $unzerReader;
+    protected UnzerReaderInterface $unzerReader;
 
     /**
      * @var \SprykerEco\Zed\Unzer\Business\Payment\Mapper\UnzerPaymentMapperInterface
      */
-    protected $unzerPaymentMapper;
+    protected UnzerPaymentMapperInterface $unzerPaymentMapper;
 
     /**
      * @var \SprykerEco\Zed\Unzer\Business\Payment\Updater\UnzerPaymentUpdaterInterface
      */
-    protected $unzerPaymentUpdater;
+    protected UnzerPaymentUpdaterInterface $unzerPaymentUpdater;
 
     /**
      * @var \SprykerEco\Zed\Unzer\Business\Credentials\UnzerCredentialsResolverInterface
      */
-    protected $unzerCredentialsResolver;
+    protected UnzerCredentialsResolverInterface $unzerCredentialsResolver;
+
+    /**
+     * @var \SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolverInterface
+     */
+    protected UnzerOmsStateResolverInterface $unzerOmsStateResolver;
 
     /**
      * @param \SprykerEco\Zed\Unzer\Business\ApiAdapter\UnzerPaymentAdapterInterface $unzerPaymentAdapter
@@ -58,6 +64,7 @@ class UnzerNotificationProcessor implements UnzerNotificationProcessorInterface
      * @param \SprykerEco\Zed\Unzer\Business\Payment\Mapper\UnzerPaymentMapperInterface $unzerPaymentMapper
      * @param \SprykerEco\Zed\Unzer\Business\Payment\Updater\UnzerPaymentUpdaterInterface $unzerPaymentUpdater
      * @param \SprykerEco\Zed\Unzer\Business\Credentials\UnzerCredentialsResolverInterface $unzerCredentialsResolver
+     * @param \SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolverInterface $unzerOmsStateResolver
      */
     public function __construct(
         UnzerPaymentAdapterInterface $unzerPaymentAdapter,
@@ -65,7 +72,8 @@ class UnzerNotificationProcessor implements UnzerNotificationProcessorInterface
         UnzerReaderInterface $unzerReader,
         UnzerPaymentMapperInterface $unzerPaymentMapper,
         UnzerPaymentUpdaterInterface $unzerPaymentUpdater,
-        UnzerCredentialsResolverInterface $unzerCredentialsResolver
+        UnzerCredentialsResolverInterface $unzerCredentialsResolver,
+        UnzerOmsStateResolverInterface $unzerOmsStateResolver
     ) {
         $this->unzerPaymentAdapter = $unzerPaymentAdapter;
         $this->unzerConfig = $unzerConfig;
@@ -73,6 +81,7 @@ class UnzerNotificationProcessor implements UnzerNotificationProcessorInterface
         $this->unzerPaymentMapper = $unzerPaymentMapper;
         $this->unzerPaymentUpdater = $unzerPaymentUpdater;
         $this->unzerCredentialsResolver = $unzerCredentialsResolver;
+        $this->unzerOmsStateResolver = $unzerOmsStateResolver;
     }
 
     /**
@@ -109,9 +118,7 @@ class UnzerNotificationProcessor implements UnzerNotificationProcessorInterface
             return $unzerNotificationTransfer;
         }
 
-        $orderItemStatus = $this->unzerConfig->mapUnzerEventToOmsStatus(
-            $unzerNotificationTransfer->getEventOrFail(),
-        );
+        $orderItemStatus = $this->unzerOmsStateResolver->getUnzerPaymentOmsStatus($unzerPaymentTransfer);
 
         $this->unzerPaymentUpdater->updateUnzerPaymentDetails($unzerPaymentTransfer, $orderItemStatus);
 

--- a/src/SprykerEco/Zed/Unzer/Business/Payment/OmsStateResolver/UnzerOmsStateResolver.php
+++ b/src/SprykerEco/Zed/Unzer/Business/Payment/OmsStateResolver/UnzerOmsStateResolver.php
@@ -39,7 +39,7 @@ class UnzerOmsStateResolver implements UnzerOmsStateResolverInterface
                 continue;
             }
 
-            if ($unzerTransactionTransfer->getTypeOrFail() === UnzerConstants::TRANSACTION_TYPE_CHARGE) {
+            if ($unzerTransactionTransfer->getTypeOrFail() === UnzerConstants::TRANSACTION_TYPE_AUTHORIZE) {
                 $authorizeUnzerTransactionTransfer = $unzerTransactionTransfer;
             }
         }

--- a/src/SprykerEco/Zed/Unzer/Business/Payment/OmsStateResolver/UnzerOmsStateResolver.php
+++ b/src/SprykerEco/Zed/Unzer/Business/Payment/OmsStateResolver/UnzerOmsStateResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver;
+
+use Generated\Shared\Transfer\UnzerPaymentTransfer;
+use SprykerEco\Zed\Unzer\UnzerConfig;
+use SprykerEco\Zed\Unzer\UnzerConstants;
+
+class UnzerOmsStateResolver implements UnzerOmsStateResolverInterface
+{
+    protected UnzerConfig $unzerConfig;
+
+    /**
+     * @param \SprykerEco\Zed\Unzer\UnzerConfig $unzerConfig
+     */
+    public function __construct(UnzerConfig $unzerConfig)
+    {
+        $this->unzerConfig = $unzerConfig;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\UnzerPaymentTransfer $unzerPaymentTransfer
+     *
+     * @return string
+     */
+    public function getUnzerPaymentOmsStatus(UnzerPaymentTransfer $unzerPaymentTransfer): string
+    {
+        $chargeUnzerTransactionTransfer = null;
+        $authorizeUnzerTransactionTransfer = null;
+        foreach ($unzerPaymentTransfer->getTransactions() as $unzerTransactionTransfer) {
+            if ($unzerTransactionTransfer->getTypeOrFail() === UnzerConstants::TRANSACTION_TYPE_CHARGE) {
+                $chargeUnzerTransactionTransfer = $unzerTransactionTransfer;
+
+                continue;
+            }
+
+            if ($unzerTransactionTransfer->getTypeOrFail() === UnzerConstants::TRANSACTION_TYPE_CHARGE) {
+                $authorizeUnzerTransactionTransfer = $unzerTransactionTransfer;
+            }
+        }
+
+        if ($chargeUnzerTransactionTransfer !== null) {
+            return $this->unzerConfig->mapUnzerChargePaymentStatusToOmsStatus($chargeUnzerTransactionTransfer->getStatusOrFail());
+        }
+
+        if ($authorizeUnzerTransactionTransfer !== null) {
+            return $this->unzerConfig->mapUnzerAuthorizePaymentStatusToOmsStatus($authorizeUnzerTransactionTransfer->getStatusOrFail());
+        }
+
+        return $this->unzerConfig->mapUnzerPaymentStatusToOmsStatus($unzerPaymentTransfer->getStateIdOrFail());
+    }
+}

--- a/src/SprykerEco/Zed/Unzer/Business/Payment/OmsStateResolver/UnzerOmsStateResolverInterface.php
+++ b/src/SprykerEco/Zed/Unzer/Business/Payment/OmsStateResolver/UnzerOmsStateResolverInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver;
+
+use Generated\Shared\Transfer\UnzerPaymentTransfer;
+
+interface UnzerOmsStateResolverInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\UnzerPaymentTransfer $unzerPaymentTransfer
+     *
+     * @return string
+     */
+    public function getUnzerPaymentOmsStatus(UnzerPaymentTransfer $unzerPaymentTransfer): string;
+}

--- a/src/SprykerEco/Zed/Unzer/Business/UnzerBusinessFactory.php
+++ b/src/SprykerEco/Zed/Unzer/Business/UnzerBusinessFactory.php
@@ -100,6 +100,8 @@ use SprykerEco\Zed\Unzer\Business\Payment\Filter\UnzerMarketplacePaymentMethodFi
 use SprykerEco\Zed\Unzer\Business\Payment\Filter\UnzerPaymentMethodFilterInterface;
 use SprykerEco\Zed\Unzer\Business\Payment\Mapper\UnzerPaymentMapper;
 use SprykerEco\Zed\Unzer\Business\Payment\Mapper\UnzerPaymentMapperInterface;
+use SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolver;
+use SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolverInterface;
 use SprykerEco\Zed\Unzer\Business\Payment\Processor\Charge\UnzerChargeProcessorInterface;
 use SprykerEco\Zed\Unzer\Business\Payment\Processor\Charge\UnzerCreditCardChargeProcessor;
 use SprykerEco\Zed\Unzer\Business\Payment\Processor\Charge\UnzerMarketplaceCreditCardChargeProcessor;
@@ -403,6 +405,17 @@ class UnzerBusinessFactory extends AbstractBusinessFactory
             $this->createUnzerPaymentMapper(),
             $this->createUnzerPaymentUpdater(),
             $this->createUnzerCredentialsResolver(),
+            $this->createUnzerOmsStateResolver(),
+        );
+    }
+
+    /**
+     * @return \SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolverInterface
+     */
+    public function createUnzerOmsStateResolver(): UnzerOmsStateResolverInterface
+    {
+        return new UnzerOmsStateResolver(
+            $this->getConfig(),
         );
     }
 

--- a/src/SprykerEco/Zed/Unzer/Business/UnzerFacade.php
+++ b/src/SprykerEco/Zed/Unzer/Business/UnzerFacade.php
@@ -81,6 +81,8 @@ class UnzerFacade extends AbstractFacade implements UnzerFacadeInterface
      *
      * @param \Generated\Shared\Transfer\UnzerNotificationTransfer $notificationTransfer
      *
+     * @throws \SprykerEco\Zed\Unzer\Business\Exception\UnzerException
+     *
      * @return \Generated\Shared\Transfer\UnzerNotificationTransfer
      */
     public function processNotification(UnzerNotificationTransfer $notificationTransfer): UnzerNotificationTransfer

--- a/src/SprykerEco/Zed/Unzer/Business/UnzerFacadeInterface.php
+++ b/src/SprykerEco/Zed/Unzer/Business/UnzerFacadeInterface.php
@@ -68,10 +68,13 @@ interface UnzerFacadeInterface
      * - Checks if provided Unzer notification is enabled.
      * - Processes Unzer notification.
      * - Updates payment details in DB.
+     * - Throws `UnzerException` if payment status cannot be mapped to OMS status correctly.
      *
      * @api
      *
      * @param \Generated\Shared\Transfer\UnzerNotificationTransfer $notificationTransfer
+     *
+     * @throws \SprykerEco\Zed\Unzer\Business\Exception\UnzerException
      *
      * @return \Generated\Shared\Transfer\UnzerNotificationTransfer
      */

--- a/src/SprykerEco/Zed/Unzer/Persistence/Propel/Mapper/UnzerMapper.php
+++ b/src/SprykerEco/Zed/Unzer/Persistence/Propel/Mapper/UnzerMapper.php
@@ -24,18 +24,18 @@ use Orm\Zed\Unzer\Persistence\SpyPaymentUnzerCustomer;
 use Orm\Zed\Unzer\Persistence\SpyPaymentUnzerOrderItem;
 use Orm\Zed\Unzer\Persistence\SpyPaymentUnzerTransaction;
 use Orm\Zed\Unzer\Persistence\SpyUnzerCredentials;
-use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\ObjectCollection;
 
 class UnzerMapper
 {
     /**
-     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerOrderItem> $paymentUnzerOrderItemEntities
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerOrderItem> $paymentUnzerOrderItemEntities
      * @param \Generated\Shared\Transfer\PaymentUnzerOrderItemCollectionTransfer $paymentUnzerOrderItemCollectionTransfer
      *
      * @return \Generated\Shared\Transfer\PaymentUnzerOrderItemCollectionTransfer
      */
     public function mapPaymentUnzerOrderItemEntitiesToPaymentUnzerOrderItemCollectionTransfer(
-        Collection $paymentUnzerOrderItemEntities,
+        ObjectCollection $paymentUnzerOrderItemEntities,
         PaymentUnzerOrderItemCollectionTransfer $paymentUnzerOrderItemCollectionTransfer
     ): PaymentUnzerOrderItemCollectionTransfer {
         foreach ($paymentUnzerOrderItemEntities as $paymentUnzerOrderItemEntity) {
@@ -210,13 +210,13 @@ class UnzerMapper
     }
 
     /**
-     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyUnzerCredentialsStore> $unzerCredentialsStoreEntities
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\Unzer\Persistence\SpyUnzerCredentialsStore> $unzerCredentialsStoreEntities
      * @param \Generated\Shared\Transfer\StoreRelationTransfer $storeRelationTransfer
      *
      * @return \Generated\Shared\Transfer\StoreRelationTransfer
      */
     public function mapUnzerCredentialsStoreEntitiesToStoreRelationTransfer(
-        Collection $unzerCredentialsStoreEntities,
+        ObjectCollection $unzerCredentialsStoreEntities,
         StoreRelationTransfer $storeRelationTransfer
     ): StoreRelationTransfer {
         foreach ($unzerCredentialsStoreEntities as $unzerCredentialsStoreEntity) {
@@ -239,13 +239,13 @@ class UnzerMapper
     }
 
     /**
-     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyUnzerCredentials> $unzerCredentialsEntities
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\Unzer\Persistence\SpyUnzerCredentials> $unzerCredentialsEntities
      * @param \Generated\Shared\Transfer\UnzerCredentialsCollectionTransfer $unzerCredentialsCollectionTransfer
      *
      * @return \Generated\Shared\Transfer\UnzerCredentialsCollectionTransfer
      */
     public function mapUnzerCredentialsEntityCollectionToUnzerCredentialsTransferCollection(
-        Collection $unzerCredentialsEntities,
+        ObjectCollection $unzerCredentialsEntities,
         UnzerCredentialsCollectionTransfer $unzerCredentialsCollectionTransfer
     ): UnzerCredentialsCollectionTransfer {
         foreach ($unzerCredentialsEntities as $unzerCredentialsEntity) {
@@ -258,13 +258,13 @@ class UnzerMapper
     }
 
     /**
-     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerTransaction> $paymentUnzerTransactionEntities
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerTransaction> $paymentUnzerTransactionEntities
      * @param \Generated\Shared\Transfer\PaymentUnzerTransactionCollectionTransfer $paymentUnzerTransactionCollectionTransfer
      *
      * @return \Generated\Shared\Transfer\PaymentUnzerTransactionCollectionTransfer
      */
     public function mapPaymentUnzerTransactionEntityCollectionToPaymentUnzerTransactionCollectionTransfer(
-        Collection $paymentUnzerTransactionEntities,
+        ObjectCollection $paymentUnzerTransactionEntities,
         PaymentUnzerTransactionCollectionTransfer $paymentUnzerTransactionCollectionTransfer
     ): PaymentUnzerTransactionCollectionTransfer {
         foreach ($paymentUnzerTransactionEntities as $paymentUnzerTransactionEntity) {

--- a/src/SprykerEco/Zed/Unzer/Persistence/Propel/Mapper/UnzerMapper.php
+++ b/src/SprykerEco/Zed/Unzer/Persistence/Propel/Mapper/UnzerMapper.php
@@ -24,18 +24,18 @@ use Orm\Zed\Unzer\Persistence\SpyPaymentUnzerCustomer;
 use Orm\Zed\Unzer\Persistence\SpyPaymentUnzerOrderItem;
 use Orm\Zed\Unzer\Persistence\SpyPaymentUnzerTransaction;
 use Orm\Zed\Unzer\Persistence\SpyUnzerCredentials;
-use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Collection\Collection;
 
 class UnzerMapper
 {
     /**
-     * @param \Propel\Runtime\Collection\ObjectCollection $paymentUnzerOrderItemEntities
+     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerOrderItem> $paymentUnzerOrderItemEntities
      * @param \Generated\Shared\Transfer\PaymentUnzerOrderItemCollectionTransfer $paymentUnzerOrderItemCollectionTransfer
      *
      * @return \Generated\Shared\Transfer\PaymentUnzerOrderItemCollectionTransfer
      */
     public function mapPaymentUnzerOrderItemEntitiesToPaymentUnzerOrderItemCollectionTransfer(
-        ObjectCollection $paymentUnzerOrderItemEntities,
+        Collection $paymentUnzerOrderItemEntities,
         PaymentUnzerOrderItemCollectionTransfer $paymentUnzerOrderItemCollectionTransfer
     ): PaymentUnzerOrderItemCollectionTransfer {
         foreach ($paymentUnzerOrderItemEntities as $paymentUnzerOrderItemEntity) {
@@ -210,13 +210,13 @@ class UnzerMapper
     }
 
     /**
-     * @param \Propel\Runtime\Collection\ObjectCollection $unzerCredentialsStoreEntities
+     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyUnzerCredentialsStore> $unzerCredentialsStoreEntities
      * @param \Generated\Shared\Transfer\StoreRelationTransfer $storeRelationTransfer
      *
      * @return \Generated\Shared\Transfer\StoreRelationTransfer
      */
     public function mapUnzerCredentialsStoreEntitiesToStoreRelationTransfer(
-        ObjectCollection $unzerCredentialsStoreEntities,
+        Collection $unzerCredentialsStoreEntities,
         StoreRelationTransfer $storeRelationTransfer
     ): StoreRelationTransfer {
         foreach ($unzerCredentialsStoreEntities as $unzerCredentialsStoreEntity) {
@@ -239,13 +239,13 @@ class UnzerMapper
     }
 
     /**
-     * @param \Propel\Runtime\Collection\ObjectCollection $unzerCredentialsEntities
+     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyUnzerCredentials> $unzerCredentialsEntities
      * @param \Generated\Shared\Transfer\UnzerCredentialsCollectionTransfer $unzerCredentialsCollectionTransfer
      *
      * @return \Generated\Shared\Transfer\UnzerCredentialsCollectionTransfer
      */
     public function mapUnzerCredentialsEntityCollectionToUnzerCredentialsTransferCollection(
-        ObjectCollection $unzerCredentialsEntities,
+        Collection $unzerCredentialsEntities,
         UnzerCredentialsCollectionTransfer $unzerCredentialsCollectionTransfer
     ): UnzerCredentialsCollectionTransfer {
         foreach ($unzerCredentialsEntities as $unzerCredentialsEntity) {
@@ -258,13 +258,13 @@ class UnzerMapper
     }
 
     /**
-     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerTransaction> $paymentUnzerTransactionEntities
+     * @param \Propel\Runtime\Collection\Collection<\Orm\Zed\Unzer\Persistence\SpyPaymentUnzerTransaction> $paymentUnzerTransactionEntities
      * @param \Generated\Shared\Transfer\PaymentUnzerTransactionCollectionTransfer $paymentUnzerTransactionCollectionTransfer
      *
      * @return \Generated\Shared\Transfer\PaymentUnzerTransactionCollectionTransfer
      */
     public function mapPaymentUnzerTransactionEntityCollectionToPaymentUnzerTransactionCollectionTransfer(
-        ObjectCollection $paymentUnzerTransactionEntities,
+        Collection $paymentUnzerTransactionEntities,
         PaymentUnzerTransactionCollectionTransfer $paymentUnzerTransactionCollectionTransfer
     ): PaymentUnzerTransactionCollectionTransfer {
         foreach ($paymentUnzerTransactionEntities as $paymentUnzerTransactionEntity) {

--- a/src/SprykerEco/Zed/Unzer/Persistence/UnzerRepository.php
+++ b/src/SprykerEco/Zed/Unzer/Persistence/UnzerRepository.php
@@ -56,6 +56,7 @@ class UnzerRepository extends AbstractRepository implements UnzerRepositoryInter
      */
     public function getPaymentUnzerOrderItemCollectionByOrderId(string $orderId): PaymentUnzerOrderItemCollectionTransfer
     {
+        /** @var \Propel\Runtime\Collection\ObjectCollection $paymentUnzerOrderItemEntities */
         $paymentUnzerOrderItemEntities = $this->getFactory()
             ->getPaymentUnzerOrderItemQuery()
             ->usePaymentUnzerQuery()
@@ -151,6 +152,7 @@ class UnzerRepository extends AbstractRepository implements UnzerRepositoryInter
      */
     public function getStoreRelationByIdUnzerCredentials(int $idUnzerCredentials): StoreRelationTransfer
     {
+        /** @var \Propel\Runtime\Collection\ObjectCollection $unzerCredentialsStoreEntities */
         $unzerCredentialsStoreEntities = $this->getFactory()
             ->getUnzerCredentialsStoreQuery()
             ->filterByFkUnzerCredentials($idUnzerCredentials)
@@ -178,6 +180,7 @@ class UnzerRepository extends AbstractRepository implements UnzerRepositoryInter
             $unzerCredentialsCriteriaTransfer->getUnzerCredentialsConditionsOrFail(),
         );
 
+        /** @var \Propel\Runtime\Collection\ObjectCollection $unzerCredentialsEntities */
         $unzerCredentialsEntities = $unzerCredentialsQuery->find();
 
         return $this->getFactory()->getUnzerMapper()
@@ -216,6 +219,7 @@ class UnzerRepository extends AbstractRepository implements UnzerRepositoryInter
             $paymentUnzerTransactionQuery,
             $paymentUnzerTransactionCriteriaTransfer->getPaymentUnzerTransactionConditionsOrFail(),
         );
+        /** @var \Propel\Runtime\Collection\ObjectCollection $paymentUnzerTransactionEntities */
         $paymentUnzerTransactionEntities = $paymentUnzerTransactionQuery->find();
 
         return $this->getFactory()->getUnzerMapper()

--- a/src/SprykerEco/Zed/Unzer/UnzerConfig.php
+++ b/src/SprykerEco/Zed/Unzer/UnzerConfig.php
@@ -52,6 +52,24 @@ class UnzerConfig extends AbstractBundleConfig
     /**
      * @var array<string, string>
      */
+    protected const UNZER_CHARGE_STATE_OMS_STATUS_MAP = [
+        UnzerConstants::TRANSACTION_STATUS_SUCCESS => UnzerConstants::OMS_STATUS_PAYMENT_COMPLETED,
+        UnzerConstants::TRANSACTION_STATUS_PENDING => UnzerConstants::OMS_STATUS_CHARGE_PENDING,
+        UnzerConstants::TRANSACTION_STATUS_ERROR => UnzerConstants::OMS_STATUS_CHARGE_FAILED,
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected const UNZER_AUTHORIZE_STATE_OMS_STATUS_MAP = [
+        UnzerConstants::TRANSACTION_STATUS_SUCCESS => UnzerConstants::OMS_STATUS_AUTHORIZE_SUCCEEDED,
+        UnzerConstants::TRANSACTION_STATUS_PENDING => UnzerConstants::OMS_STATUS_AUTHORIZE_PENDING,
+        UnzerConstants::TRANSACTION_STATUS_ERROR => UnzerConstants::OMS_STATUS_AUTHORIZE_FAILED,
+    ];
+
+    /**
+     * @var array<string, string>
+     */
     protected const UNZER_EVENT_OMS_STATUS_MAP = [
         UnzerConstants::NOTIFICATION_TYPE_AUTHORIZE_SUCCESS => UnzerConstants::OMS_STATUS_AUTHORIZE_SUCCEEDED,
         UnzerConstants::NOTIFICATION_TYPE_AUTHORIZE_PENDING => UnzerConstants::OMS_STATUS_AUTHORIZE_PENDING,
@@ -367,6 +385,8 @@ class UnzerConfig extends AbstractBundleConfig
      *
      * @api
      *
+     * @deprecated Will be removed without replacement.
+     *
      * @param string $unzerEvent
      *
      * @return string
@@ -374,6 +394,36 @@ class UnzerConfig extends AbstractBundleConfig
     public function mapUnzerEventToOmsStatus(string $unzerEvent): string
     {
         return static::UNZER_EVENT_OMS_STATUS_MAP[$unzerEvent];
+    }
+
+    /**
+     * Specification:
+     * - Maps Unzer charge transaction status to OMS status.
+     *
+     * @api
+     *
+     * @param string $transactionStatus
+     *
+     * @return string
+     */
+    public function mapUnzerChargePaymentStatusToOmsStatus(string $transactionStatus): string
+    {
+        return static::UNZER_CHARGE_STATE_OMS_STATUS_MAP[$transactionStatus];
+    }
+
+    /**
+     * Specification:
+     * - Maps Unzer authorize transaction status to OMS status.
+     *
+     * @api
+     *
+     * @param string $transactionStatus
+     *
+     * @return string
+     */
+    public function mapUnzerAuthorizePaymentStatusToOmsStatus(string $transactionStatus): string
+    {
+        return static::UNZER_AUTHORIZE_STATE_OMS_STATUS_MAP[$transactionStatus];
     }
 
     /**

--- a/src/SprykerEco/Zed/Unzer/UnzerConfig.php
+++ b/src/SprykerEco/Zed/Unzer/UnzerConfig.php
@@ -355,6 +355,8 @@ class UnzerConfig extends AbstractBundleConfig
      *
      * @api
      *
+     * @deprecated Will be removed without replacement.
+     *
      * @param int $unzerStateId
      *
      * @return string
@@ -362,6 +364,19 @@ class UnzerConfig extends AbstractBundleConfig
     public function mapUnzerPaymentStatusToOmsStatus(int $unzerStateId): string
     {
         return static::UNZER_PAYMENT_STATE_OMS_STATUS_MAP[$unzerStateId];
+    }
+
+    /**
+     * Specification:
+     * - Returns Unzer payment state to OMS status map.
+     *
+     * @api
+     *
+     * @return array<int, string>
+     */
+    public function getUnzerPaymentStateToOmsStatusMap(): string
+    {
+        return static::UNZER_PAYMENT_STATE_OMS_STATUS_MAP;
     }
 
     /**
@@ -398,32 +413,28 @@ class UnzerConfig extends AbstractBundleConfig
 
     /**
      * Specification:
-     * - Maps Unzer charge transaction status to OMS status.
+     * - Returns Unzer charge transaction status to OMS status map.
      *
      * @api
      *
-     * @param string $transactionStatus
-     *
-     * @return string
+     * @return array<string, string>
      */
-    public function mapUnzerChargePaymentStatusToOmsStatus(string $transactionStatus): string
+    public function getUnzerChargePaymentStatusToOmsStatusMap(): array
     {
-        return static::UNZER_CHARGE_STATE_OMS_STATUS_MAP[$transactionStatus];
+        return static::UNZER_CHARGE_STATE_OMS_STATUS_MAP;
     }
 
     /**
      * Specification:
-     * - Maps Unzer authorize transaction status to OMS status.
+     * - Returns Unzer authorize transaction status to OMS status map.
      *
      * @api
      *
-     * @param string $transactionStatus
-     *
-     * @return string
+     * @return array<string, string>
      */
-    public function mapUnzerAuthorizePaymentStatusToOmsStatus(string $transactionStatus): string
+    public function getUnzerAuthorizePaymentStatusToOmsStatusMap(): array
     {
-        return static::UNZER_AUTHORIZE_STATE_OMS_STATUS_MAP[$transactionStatus];
+        return static::UNZER_AUTHORIZE_STATE_OMS_STATUS_MAP;
     }
 
     /**

--- a/src/SprykerEco/Zed/Unzer/UnzerConfig.php
+++ b/src/SprykerEco/Zed/Unzer/UnzerConfig.php
@@ -374,7 +374,7 @@ class UnzerConfig extends AbstractBundleConfig
      *
      * @return array<int, string>
      */
-    public function getUnzerPaymentStateToOmsStatusMap(): string
+    public function getUnzerPaymentStateToOmsStatusMap(): array
     {
         return static::UNZER_PAYMENT_STATE_OMS_STATUS_MAP;
     }

--- a/src/SprykerEco/Zed/Unzer/UnzerConstants.php
+++ b/src/SprykerEco/Zed/Unzer/UnzerConstants.php
@@ -265,6 +265,16 @@ interface UnzerConstants
     public const TRANSACTION_STATUS_SUCCESS = 'success';
 
     /**
+     * @var string
+     */
+    public const TRANSACTION_STATUS_PENDING = 'pending';
+
+    /**
+     * @var string
+     */
+    public const TRANSACTION_STATUS_ERROR = 'error';
+
+    /**
      * @var int
      */
     public const INT_TO_FLOAT_DIVIDER = 100;

--- a/tests/SprykerEcoTest/Zed/Unzer/Business/Payment/UnzerOmsStateResolverTest.php
+++ b/tests/SprykerEcoTest/Zed/Unzer/Business/Payment/UnzerOmsStateResolverTest.php
@@ -11,94 +11,154 @@ use Codeception\Test\Unit;
 use Generated\Shared\Transfer\UnzerPaymentTransfer;
 use Generated\Shared\Transfer\UnzerTransactionTransfer;
 use SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolver;
-use SprykerEco\Zed\Unzer\UnzerConfig;
 use SprykerEco\Zed\Unzer\UnzerConstants;
+use SprykerEcoTest\Zed\Unzer\UnzerBusinessTester;
 
 class UnzerOmsStateResolverTest extends Unit
 {
     /**
-     * @dataProvider unzerPaymentStatusDataProvider
-     *
-     * @param string $expectedOmsState
-     * @param \Generated\Shared\Transfer\UnzerPaymentTransfer $paymentTransfer
-     *
+     * @var \SprykerEcoTest\Zed\Unzer\UnzerBusinessTester
+     */
+    protected UnzerBusinessTester $tester;
+
+    /**
      * @return void
      */
-    public function testShouldReturn(string $expectedOmsState, UnzerPaymentTransfer $paymentTransfer): void
+    public function getUnzerPaymentOmsStatusShouldReturnStatusAuthorizePendingWhenTransactionAuthorizePending(): void
     {
+        // Arrange
+        $paymentTransfer = (new UnzerPaymentTransfer())
+            ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_PENDING),
+            );
+
         // Act
-        $omsState = (new UnzerOmsStateResolver(new UnzerConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+        $omsState = (new UnzerOmsStateResolver($this->tester->createConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
 
         // Assert
-        $this->assertSame($expectedOmsState, $omsState);
+        $this->assertSame(UnzerConstants::OMS_STATUS_AUTHORIZE_PENDING, $omsState);
     }
 
     /**
-     * @return array<string, mixed>
+     * @return void
      */
-    protected function unzerPaymentStatusDataProvider(): array
+    public function getUnzerPaymentOmsStatusShouldReturnStatusAuthorizeSuccessWhenTransactionAuthorizeSuccess(): void
     {
-        return [
-            'Payment status authorize pending' => [
-                UnzerConstants::OMS_STATUS_AUTHORIZE_PENDING,
-                (new UnzerPaymentTransfer())
-                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_PENDING),
-                    ),
-            ],
-            'Payment status authorize success' => [
-                UnzerConstants::OMS_STATUS_AUTHORIZE_SUCCEEDED,
-                (new UnzerPaymentTransfer())
-                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
-                    ),
-            ],
-            'Payment status authorize failed' => [
-                UnzerConstants::OMS_STATUS_AUTHORIZE_FAILED,
-                (new UnzerPaymentTransfer())
-                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_PENDING),
-                    ),
-            ],
-            'Payment status charge failed' => [
-                UnzerConstants::OMS_STATUS_CHARGE_FAILED,
-                (new UnzerPaymentTransfer())
-                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_CANCELED)
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
-                    )
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_ERROR),
-                    ),
-            ],
-            'Payment status payment completed' => [
-                UnzerConstants::OMS_STATUS_PAYMENT_COMPLETED,
-                (new UnzerPaymentTransfer())
-                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
-                    )
-                    ->addTransaction(
-                        (new UnzerTransactionTransfer())
-                            ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
-                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
-                    ),
-            ],
-        ];
+        // Arrange
+        $paymentTransfer = (new UnzerPaymentTransfer())
+            ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+            );
+
+        // Act
+        $omsState = (new UnzerOmsStateResolver($this->tester->createConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+
+        // Assert
+        $this->assertSame(UnzerConstants::OMS_STATUS_AUTHORIZE_SUCCEEDED, $omsState);
+    }
+
+    /**
+     * @return void
+     */
+    public function getUnzerPaymentOmsStatusShouldReturnStatusAuthorizeFailedWhenTransactionAuthorizeFailed(): void
+    {
+        // Arrange
+        $paymentTransfer = (new UnzerPaymentTransfer())
+            ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_PENDING),
+            );
+
+        // Act
+        $omsState = (new UnzerOmsStateResolver($this->tester->createConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+
+        // Assert
+        $this->assertSame(UnzerConstants::OMS_STATUS_AUTHORIZE_FAILED, $omsState);
+    }
+
+    /**
+     * @return void
+     */
+    public function getUnzerPaymentOmsStatusShouldReturnStatusChargeFailedWhenTransactionChargeFailed(): void
+    {
+        // Arrange
+        $paymentTransfer = (new UnzerPaymentTransfer())
+            ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_CANCELED)
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+            )
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_ERROR),
+            );
+
+        // Act
+        $omsState = (new UnzerOmsStateResolver($this->tester->createConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+
+        // Assert
+        $this->assertSame(UnzerConstants::OMS_STATUS_CHARGE_FAILED, $omsState);
+    }
+
+    /**
+     * @return void
+     */
+    public function getUnzerPaymentOmsStatusShouldReturnPaymentCompletedWhenPaymentCompleted(): void
+    {
+        // Arrange
+        $paymentTransfer = (new UnzerPaymentTransfer())
+            ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+            )
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+            );
+
+        // Act
+        $omsState = (new UnzerOmsStateResolver($this->tester->createConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+
+        // Assert
+        $this->assertSame(UnzerConstants::OMS_STATUS_PAYMENT_COMPLETED, $omsState);
+    }
+
+    /**
+     * @return void
+     */
+    public function getUnzerPaymentOmsStatusShouldThrowExceptionWhenTransactionStatusIsUnknown(): void
+    {
+        // Arrange
+        $paymentTransfer = (new UnzerPaymentTransfer())
+            ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+            )
+            ->addTransaction(
+                (new UnzerTransactionTransfer())
+                    ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
+                    ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+            );
+
+        // Act
+        $omsState = (new UnzerOmsStateResolver($this->tester->createConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+
+        // Assert
+        $this->assertSame(UnzerConstants::OMS_STATUS_PAYMENT_COMPLETED, $omsState);
     }
 }

--- a/tests/SprykerEcoTest/Zed/Unzer/Business/Payment/UnzerOmsStateResolverTest.php
+++ b/tests/SprykerEcoTest/Zed/Unzer/Business/Payment/UnzerOmsStateResolverTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerEcoTest\Zed\Unzer\Business\Payment;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\UnzerPaymentTransfer;
+use Generated\Shared\Transfer\UnzerTransactionTransfer;
+use SprykerEco\Zed\Unzer\Business\Payment\OmsStateResolver\UnzerOmsStateResolver;
+use SprykerEco\Zed\Unzer\UnzerConfig;
+use SprykerEco\Zed\Unzer\UnzerConstants;
+
+class UnzerOmsStateResolverTest extends Unit
+{
+    /**
+     * @dataProvider unzerPaymentStatusDataProvider
+     *
+     * @param string $expectedOmsState
+     * @param \Generated\Shared\Transfer\UnzerPaymentTransfer $paymentTransfer
+     *
+     * @return void
+     */
+    public function testShouldReturn(string $expectedOmsState, UnzerPaymentTransfer $paymentTransfer): void
+    {
+        // Act
+        $omsState = (new UnzerOmsStateResolver(new UnzerConfig()))->getUnzerPaymentOmsStatus($paymentTransfer);
+
+        // Assert
+        $this->assertSame($expectedOmsState, $omsState);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function unzerPaymentStatusDataProvider(): array
+    {
+        return [
+            'Payment status authorize pending' => [
+                UnzerConstants::OMS_STATUS_AUTHORIZE_PENDING,
+                (new UnzerPaymentTransfer())
+                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_PENDING),
+                    ),
+            ],
+            'Payment status authorize success' => [
+                UnzerConstants::OMS_STATUS_AUTHORIZE_SUCCEEDED,
+                (new UnzerPaymentTransfer())
+                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+                    ),
+            ],
+            'Payment status authorize failed' => [
+                UnzerConstants::OMS_STATUS_AUTHORIZE_FAILED,
+                (new UnzerPaymentTransfer())
+                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_PENDING),
+                    ),
+            ],
+            'Payment status charge failed' => [
+                UnzerConstants::OMS_STATUS_CHARGE_FAILED,
+                (new UnzerPaymentTransfer())
+                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_CANCELED)
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+                    )
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_ERROR),
+                    ),
+            ],
+            'Payment status payment completed' => [
+                UnzerConstants::OMS_STATUS_PAYMENT_COMPLETED,
+                (new UnzerPaymentTransfer())
+                    ->setStateId(UnzerConstants::UNZER_PAYMENT_STATUS_PENDING)
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_AUTHORIZE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+                    )
+                    ->addTransaction(
+                        (new UnzerTransactionTransfer())
+                            ->setType(UnzerConstants::TRANSACTION_TYPE_CHARGE)
+                            ->setStatus(UnzerConstants::TRANSACTION_STATUS_SUCCESS),
+                    ),
+            ],
+        ];
+    }
+}

--- a/tests/SprykerEcoTest/Zed/Unzer/_support/Business/UnzerFacadeBaseTest.php
+++ b/tests/SprykerEcoTest/Zed/Unzer/_support/Business/UnzerFacadeBaseTest.php
@@ -7,7 +7,7 @@
 
 namespace SprykerEcoTest\Zed\Unzer\Business;
 
-use Codeception\TestCase\Test;
+use Codeception\Test\Unit;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Spryker\Service\UtilText\UtilTextService;
 use Spryker\Zed\Locale\Business\LocaleFacade;
@@ -25,7 +25,7 @@ use SprykerEco\Zed\Unzer\Dependency\UnzerToVaultFacadeBridge;
 use SprykerEco\Zed\UnzerApi\Business\UnzerApiFacade;
 use SprykerEcoTest\Zed\Unzer\UnzerBusinessTester;
 
-class UnzerFacadeBaseTest extends Test
+class UnzerFacadeBaseTest extends Unit
 {
     /**
      * @var string

--- a/tests/SprykerEcoTest/Zed/Unzer/_support/UnzerBusinessTester.php
+++ b/tests/SprykerEcoTest/Zed/Unzer/_support/UnzerBusinessTester.php
@@ -77,7 +77,7 @@ use SprykerEco\Zed\Unzer\UnzerConfig;
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = null)
  *
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(\SprykerEcoTest\Zed\Unzer\PHPMD)
  */
 class UnzerBusinessTester extends Actor
 {


### PR DESCRIPTION
- Developer(s): @kkicheglovspryker 

- Ticket: https://spryker.atlassian.net/browse/SUPESC-755

- Release Group: https://release.spryker.com/release-groups/view/5168

- PR Overview: https://release.spryker.com/release/pull-request-eco/Unzer/35

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Unzer                 | minor                 |                        |

-----------------------------------------

#### Module Unzer

##### Change log

Improvements

- Adjusted `UnzerFacade::processNotification()` so it will change the order item state based on the Unzer payment state and not on the received event name.
- Introduced `UnzerConfig::getUnzerChargePaymentStatusToOmsStatusMap()`.
- Introduced `UnzerConfig::getUnzerAuthorizePaymentStatusToOmsStatusMap()`.
- Introduced `UnzerConfig::getUnzerPaymentStateToOmsStatusMap()`.

Adjustments

- Increased `php` version to 8.1.

Deprecations

- Deprecated `UnzerConfig::mapUnzerEventToOmsStatus()`.
- Deprecated `UnzerConfig::mapUnzerPaymentStatusToOmsStatus()`.

-----------------------------------------